### PR TITLE
BaseEntity 추가

### DIFF
--- a/src/main/java/com/kcs3/panda/domain/model/BaseEntity.java
+++ b/src/main/java/com/kcs3/panda/domain/model/BaseEntity.java
@@ -1,27 +1,70 @@
 package com.kcs3.panda.domain.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.Instant;
 
-@Data
+@Getter
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
+@NoArgsConstructor
+@AllArgsConstructor
 public class BaseEntity {
-    @Column(name = "created_at", updatable = false)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     @CreatedDate
-    private Instant createdAt;
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
 
-    @Column(name = "updated_at")
     @LastModifiedDate
-    private Instant updatedAt;
-    private Instant deletedAt; //Instant 부분을 LocalDateTim으로 할 수도 있다.
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!this.getClass().equals(obj.getClass())) {
+            return false;
+        }
+        BaseEntity baseEntity = (BaseEntity) obj;
+        return Objects.equals(this.id, baseEntity.id);
+    }
+
+    @Override
+    public int hashCode() {
+        if (id == null) {
+            return 0;
+        }
+        return id.hashCode();
+    }
 }
 

--- a/src/main/java/com/kcs3/panda/domain/model/BaseEntity.java
+++ b/src/main/java/com/kcs3/panda/domain/model/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.kcs3.panda.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Data;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Data
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class BaseEntity {
+    @Column(name = "created_at", updatable = false)
+    @CreatedDate
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private Instant updatedAt;
+    private Instant deletedAt; //Instant 부분을 LocalDateTim으로 할 수도 있다.
+
+}
+


### PR DESCRIPTION
id, 생성일자,업데이트 일자를 기본으로 포함하는 BaseEntity추가

사용예시
![image](https://github.com/KCS-final/52panda-back/assets/58655693/9db61e09-ee3d-4866-bae5-7f026d4ea024)
