### PR TITLE
🚑  경매 물품에 관한 Entity 수정

### DIFF
--- a/src/main/java/com/kcs3/panda/domain/auction/entity/AuctionCompleteItem.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/entity/AuctionCompleteItem.java
@@ -1,6 +1,7 @@
 package com.kcs3.panda.domain.auction.entity;
 
 import com.kcs3.panda.domain.model.BaseEntity;
+import com.kcs3.panda.domain.user.entity.User;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
@@ -27,16 +28,29 @@ public class AuctionCompleteItem extends BaseEntity {
     @Column(name="auctionCompleteItemId", nullable = false)
     private Long auctionCompleteItemId;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "itemId", nullable = false)
+    private Item item;
 
     @Column(nullable = false)
     private String ItemTitle;
-    @Column(nullable=false)
+
+    @Column(nullable = false)
+    private String thumbnail;
+
+    @Column(nullable = false)
     private int starPrice;
     private int buyNowPrice;
+
+    @Column(nullable = false)
     private LocalDateTime bidFinishTime;
-    @Column(nullable=false)
+
+    @Column(nullable = false)
     private String location;
-    @Column(nullable=false)
-    private int maxPrice;
-    private String maxPersonID;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = true)
+    private User user;
+    private String maxPersonNickName;
+    private Integer maxPrice;
 }

--- a/src/main/java/com/kcs3/panda/domain/auction/entity/AuctionProgressItem.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/entity/AuctionProgressItem.java
@@ -1,6 +1,7 @@
 package com.kcs3.panda.domain.auction.entity;
 
 import com.kcs3.panda.domain.model.BaseEntity;
+import com.kcs3.panda.domain.user.entity.User;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
@@ -21,24 +22,34 @@ import org.hibernate.annotations.DynamicUpdate;
 @Table(name = "AuctionProgressItem")
 public class AuctionProgressItem extends BaseEntity {
 
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="auctionProgressItemId", nullable = false)
     private Long auctionProgressItemId;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "itemId", nullable = false)
+    private Item item;
 
     @Column(nullable = false)
     private String ItemTitle;
+
+    @Column(nullable = false)
+    private String thumbnail;
+
     @Column(nullable = false)
     private int starPrice;
     private int buyNowPrice;
+
+    @Column(nullable = false)
     private LocalDateTime bidFinishTime;
+
     @Column(nullable = false)
     private String location;
-    @Column(nullable = false)
-    private int maxPrice;
-    private String maxPersonID;
 
-
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = true)
+    private User user;
+    private String maxPersonNickName;
+    private Integer maxPrice;
 }

--- a/src/main/java/com/kcs3/panda/domain/auction/entity/Item.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/entity/Item.java
@@ -38,22 +38,10 @@ public class Item extends BaseEntity {
     @JoinColumn(name = "tradingMethodId", nullable = false)
     private TradingMethod tradingMethod;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "AuctionProgressItemId", nullable = true)
-    private AuctionProgressItem auctionProgressItem;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "AuctionCompleteItemId", nullable = true)
-    private AuctionCompleteItem auctionCompleteItem;
-
     @ManyToOne
     @JoinColumn(name = "locationId", nullable = false)
     private Region region;
 
     @Column(nullable = false)
-    private String thumbnail;
-
-    @Column(nullable = false)
     private boolean isAuctionComplete;
-
 }


### PR DESCRIPTION
🚑  경매 물품에 관한 Entity 수정
---

![스크린샷 2024-04-30 오후 5 29 46](https://github.com/KCS-final/52panda-back/assets/99975067/a3cc73ae-07ee-41aa-a561-b96b7ec07d76)

1. 경매 물품과 경매 중 물품 테이블, 경매 완료 물품 테이블 간의 부모-자식 관계 역전
2. 경매 물품 테이블에 있던 대표이미지 컬럼을 경매 중 물품 테이블과 경매 완료 물품 테이블에 각각 추가


---
- [ ] #22