### PR TITLE
✨ 경매 물품 즉시 입찰 기능 추가

### DIFF
--- a/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
@@ -43,6 +43,15 @@ public class AuctionBidServiceImpl implements AuctionBidService {
         AuctionProgressItem progressItem = auctionProgressItemRepo.findByItemId(itemId)
                 .orElseThrow(() -> new CommonException(ErrorCode.ITEM_NOT_FOUND));
 
+        if (bidPrice >= progressItem.getBuyNowPrice()) {
+            log.info("User {}가 Item {}을 즉시 구매 - 가격: {}", itemId, userId, bidPrice);
+
+            saveAuctionInfo(itemId, userId, bidPrice);
+            updateAuctionProgressItemMaxBid(progressItem, nickname, bidPrice);
+            transferItemToComplete(progressItem);
+            return true;
+        }
+
         Optional<AuctionBidHighestDto> highestBid
                 = auctionProgressItemRepo.findAuctionBidHighestByAuctionProgressItemId(progressItem.getAuctionProgressItemId());
 


### PR DESCRIPTION
✨ 즉시 입찰 기능 추가
---
입찰 요청 시 물품의 즉시 입찰가와 사용자의 입찰 금액이 동일할 경우 즉시 해당 사용자에게 낙찰 처리함.
 - 경매 진행 중 테이블에서 물품의 최고 입찰자 데이터를 기반으로 낙찰 여부 계산
 - 경매 진행 중 테이블에서 물품 정보 삭제
 - 경매 완료 테이블에 물품 정보 업데이트

---
- [x] #5 