### PR TITLE
🐛 경매 기능에 관한 오류 수정

### DIFF
--- a/src/main/java/com/kcs3/panda/domain/auction/entity/AuctionProgressItem.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/entity/AuctionProgressItem.java
@@ -51,7 +51,8 @@ public class AuctionProgressItem extends BaseEntity {
     private String maxPersonNickName;
     private Integer maxPrice;
 
-    public void updateAuctionMaxBid(String nickname, int price) {
+    public void updateAuctionMaxBid(User user, String nickname, int price) {
+        this.user = user;
         this.maxPersonNickName = nickname;
         this.maxPrice = price;
     }

--- a/src/main/java/com/kcs3/panda/domain/auction/entity/AuctionProgressItem.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/entity/AuctionProgressItem.java
@@ -49,7 +49,17 @@ public class AuctionProgressItem extends BaseEntity {
     @JoinColumn(name = "userId")
     private User user;
     private String maxPersonNickName;
+
+    //@Column(nullable = false)
     private Integer maxPrice;
+
+    public static class AuctionProgressItemBuilder {
+        public AuctionProgressItemBuilder startPrice(int startPrice) {
+            this.startPrice = startPrice;
+            this.maxPrice = startPrice;
+            return this;
+        }
+    }
 
     public void updateAuctionMaxBid(User user, String nickname, int price) {
         this.user = user;

--- a/src/main/java/com/kcs3/panda/domain/auction/entity/Item.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/entity/Item.java
@@ -40,4 +40,8 @@ public class Item extends BaseEntity {
 
     @Column(nullable = false)
     private boolean isAuctionComplete;
+
+    public void endAuction() {
+        this.isAuctionComplete = true;
+    }
 }

--- a/src/main/java/com/kcs3/panda/domain/auction/repository/AuctionProgressItemRepository.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/repository/AuctionProgressItemRepository.java
@@ -12,7 +12,13 @@ import java.time.LocalDateTime;
 
 public interface AuctionProgressItemRepository extends JpaRepository<AuctionProgressItem, Long> {
     Optional<AuctionProgressItem> findByItemItemId(Long itemId);
-    Optional<AuctionBidHighestDto> findAuctionBidHighestByAuctionProgressItemId(Long auctionProgressItemId);
+
+    @Query("SELECT new com.kcs3.panda.domain.auction.dto.AuctionBidHighestDto(" +
+            "api.auctionProgressItemId, user.userId, user.userNickname, api.maxPrice) " +
+            "FROM AuctionProgressItem api " +
+            "JOIN api.user user " +
+            "WHERE api.auctionProgressItemId = :auctionProgressItemId")
+    Optional<AuctionBidHighestDto> findAuctionBidHighestByAuctionProgressItemId(@Param("auctionProgressItemId") Long auctionProgressItemId);
 
     Optional<List<AuctionProgressItem>> findAllByBidFinishTimeBefore(LocalDateTime now);
 }

--- a/src/main/java/com/kcs3/panda/domain/auction/repository/AuctionProgressItemRepository.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/repository/AuctionProgressItemRepository.java
@@ -3,15 +3,16 @@ package com.kcs3.panda.domain.auction.repository;
 import com.kcs3.panda.domain.auction.dto.AuctionBidHighestDto;
 import com.kcs3.panda.domain.auction.entity.AuctionProgressItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 import java.time.LocalDateTime;
 
 public interface AuctionProgressItemRepository extends JpaRepository<AuctionProgressItem, Long> {
-    Optional<AuctionProgressItem> findByItemId(Long itemId);
+    Optional<AuctionProgressItem> findByItemItemId(Long itemId);
     Optional<AuctionBidHighestDto> findAuctionBidHighestByAuctionProgressItemId(Long auctionProgressItemId);
 
     Optional<List<AuctionProgressItem>> findAllByBidFinishTimeBefore(LocalDateTime now);
 }
-

--- a/src/main/java/com/kcs3/panda/domain/auction/repository/ItemRepository.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/repository/ItemRepository.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 @Repository
 public interface  ItemRepository extends JpaRepository<Item, Long> {
+        Long findSellerIdByItemId(Long itemId);
 
 
 

--- a/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
@@ -113,6 +113,11 @@ public class AuctionBidServiceImpl implements AuctionBidService {
         try {
             boolean isComplete = checkBidCompletionStatus(item);
             AuctionCompleteItem completeItem = buildAuctionCompleteItem(item, isComplete);
+
+            Item auctionItem = item.getItem();
+            auctionItem.endAuction();
+
+            itemRepository.save(auctionItem);
             auctionCompleteItemRepo.save(completeItem);
             auctionProgressItemRepo.delete(item);
         } catch (CommonException e) {

--- a/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
@@ -40,7 +40,7 @@ public class AuctionBidServiceImpl implements AuctionBidService {
 
     @Transactional
     public boolean attemptBid(Long itemId, Long userId, String nickname, int bidPrice) {
-        AuctionProgressItem progressItem = auctionProgressItemRepo.findByItemId(itemId)
+        AuctionProgressItem progressItem = auctionProgressItemRepo.findByItemItemId(itemId)
                 .orElseThrow(() -> new CommonException(ErrorCode.ITEM_NOT_FOUND));
 
         if (bidPrice >= progressItem.getBuyNowPrice()) {

--- a/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
@@ -44,10 +44,10 @@ public class AuctionBidServiceImpl implements AuctionBidService {
                 .orElseThrow(() -> new CommonException(ErrorCode.ITEM_NOT_FOUND));
 
         if (bidPrice >= progressItem.getBuyNowPrice()) {
-            log.info("User {}가 Item {}을 즉시 구매 - 가격: {}", itemId, userId, bidPrice);
+            log.debug("User {}가 Item {}을 즉시 구매 - 가격: {}", itemId, userId, bidPrice);
 
             saveAuctionInfo(itemId, userId, bidPrice);
-            updateAuctionProgressItemMaxBid(progressItem, nickname, bidPrice);
+            updateAuctionProgressItemMaxBid(progressItem, userId, nickname, bidPrice);
             transferItemToComplete(progressItem);
             return true;
         }
@@ -65,7 +65,7 @@ public class AuctionBidServiceImpl implements AuctionBidService {
         });
 
         saveAuctionInfo(itemId, userId, bidPrice);
-        updateAuctionProgressItemMaxBid(progressItem, nickname, bidPrice);
+        updateAuctionProgressItemMaxBid(progressItem, userId, nickname, bidPrice);
         return true;
     }//end attemptBid()
 
@@ -88,8 +88,9 @@ public class AuctionBidServiceImpl implements AuctionBidService {
         auctionInfoRepo.save(auctionInfo);
     }//end saveAuctionInfo()
 
-    private void updateAuctionProgressItemMaxBid(AuctionProgressItem progressItem, String nickname, int price) {
-        progressItem.updateAuctionMaxBid(nickname, price);
+    private void updateAuctionProgressItemMaxBid(AuctionProgressItem progressItem, Long userId, String nickname, int bidPrice) {
+        User user = userRepository.getReferenceById(userId);
+        progressItem.updateAuctionMaxBid(user, nickname, bidPrice);
         auctionProgressItemRepo.save(progressItem);
     }//end updateAuctionProgressItemMaxBid()
 

--- a/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
@@ -43,6 +43,11 @@ public class AuctionBidServiceImpl implements AuctionBidService {
         AuctionProgressItem progressItem = auctionProgressItemRepo.findByItemItemId(itemId)
                 .orElseThrow(() -> new CommonException(ErrorCode.ITEM_NOT_FOUND));
 
+        Long sellerId = itemRepository.findSellerIdByItemId(itemId);
+        if (sellerId.equals(userId)) {
+            throw new CommonException(ErrorCode.BIDDER_IS_SELLER);
+        }
+
         if (bidPrice >= progressItem.getBuyNowPrice()) {
             log.debug("User {}가 Item {}을 즉시 구매 - 가격: {}", itemId, userId, bidPrice);
 

--- a/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
@@ -97,7 +97,7 @@ public class AuctionBidServiceImpl implements AuctionBidService {
 
     @Transactional
     @Scheduled(cron = "0 0 * * * *")  // 매 시간 정각에 실행
-    public void transferCompletedAuctions() {
+    public void finishAuctionsByTime() {
         LocalDateTime now = LocalDateTime.now();
         Optional<List<AuctionProgressItem>> completedItemsOptional = auctionProgressItemRepo.findAllByBidFinishTimeBefore(now);
 

--- a/src/main/java/com/kcs3/panda/global/exception/ErrorCode.java
+++ b/src/main/java/com/kcs3/panda/global/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     BID_NOT_HIGHER(40008, HttpStatus.BAD_REQUEST, "입찰 가격이 현재 최고 입찰가보다 높아야 합니다."),
     BIDDER_IS_SAME(40009, HttpStatus.BAD_REQUEST, "현재 최고 입찰자와 같은 사용자입니다."),
     ITEM_BID_FIELD_MISMATCH(40010, HttpStatus.BAD_REQUEST, "경매 아이템 입찰자 정보 필드에 일관성 문제가 발생했습니다."),
+    BIDDER_IS_SELLER(40011, HttpStatus.BAD_REQUEST, "물품 판매자와 같은 사용자입니다."),
 
     // Gone Error
     GONE_SHARED_URL(41001, HttpStatus.GONE, "해당 공유 URL이 만료되었습니다."),

--- a/src/test/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImplTest.java
+++ b/src/test/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImplTest.java
@@ -1,0 +1,135 @@
+package com.kcs3.panda.domain.auction.service;
+
+import com.kcs3.panda.domain.auction.dto.AuctionBidHighestDto;
+import com.kcs3.panda.domain.auction.entity.*;
+import com.kcs3.panda.domain.auction.repository.AuctionCompleteItemRepository;
+import com.kcs3.panda.domain.auction.repository.AuctionInfoRepository;
+import com.kcs3.panda.domain.auction.repository.AuctionProgressItemRepository;
+import com.kcs3.panda.domain.auction.repository.ItemRepository;
+import com.kcs3.panda.domain.user.entity.User;
+import com.kcs3.panda.domain.user.repository.UserRepository;
+import com.kcs3.panda.global.exception.CommonException;
+import com.kcs3.panda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AuctionBidServiceImplTest {
+    @Mock
+    private AuctionProgressItemRepository auctionProgressItemRepo;
+    @Mock
+    private AuctionInfoRepository auctionInfoRepo;
+    @Mock
+    private AuctionCompleteItemRepository auctionCompleteItemRepo;
+    @Mock
+    private ItemRepository itemRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private AuctionBidServiceImpl auctionBidService;
+
+    private final Long itemId = 1L;
+    private final Long userId = 1L;
+    private final String nickname = "Test user";
+    private AuctionProgressItem progressItem;
+    private AuctionBidHighestDto highestBidDto;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        Item mockItem = Item.builder()
+                .itemId(itemId)
+                .build();
+        when(itemRepository.getReferenceById(itemId)).thenReturn(mockItem);
+
+        User mockUser = new User();
+        mockUser.setUserId(userId);
+        mockUser.setUserNickname(nickname);
+        when(userRepository.getReferenceById(userId)).thenReturn(mockUser);
+
+        /*
+        // for Builder
+        User mockUser = User.builder()
+                .userId(userId)
+                .userNickname(nickname)
+                .build();
+        when(userRepository.getReferenceById(userId)).thenReturn(mockUser);
+         */
+
+        progressItem = AuctionProgressItem.builder()
+                .auctionProgressItemId(itemId)
+                .item(mockItem)
+                .itemTitle("Test Item")
+                .thumbnail("test-thumbnail.jpg")
+                .startPrice(5000)
+                .buyNowPrice(10000)
+                .build();
+
+        when(auctionProgressItemRepo.findByItemItemId(itemId)).thenReturn(Optional.of(progressItem));
+    }
+
+
+    private void setupAuctionBidTest(Long highestBidUserId, int highestBidAmount) {
+        highestBidDto = AuctionBidHighestDto.builder()
+                .auctionProgressItemId(progressItem.getAuctionProgressItemId())
+                .userId(highestBidUserId)
+                .maxPersonNickName("Current highest bidder")
+                .maxPrice(highestBidAmount)
+                .build();
+        when(auctionProgressItemRepo.findByItemItemId(itemId)).thenReturn(Optional.of(progressItem));
+        when(auctionProgressItemRepo.findAuctionBidHighestByAuctionProgressItemId(progressItem.getAuctionProgressItemId())).thenReturn(Optional.of(highestBidDto));
+    }
+
+    @Test
+    void attemptBid_basic_success() {
+        setupAuctionBidTest(2L, 5000);
+        int newBidPrice = 6000;
+
+        boolean result = auctionBidService.attemptBid(itemId, userId, nickname, newBidPrice);
+
+        assertTrue(result);
+        verify(auctionInfoRepo).save(any(AuctionInfo.class));
+        verify(auctionProgressItemRepo).save(any(AuctionProgressItem.class));
+        verify(auctionCompleteItemRepo, never()).save(any(AuctionCompleteItem.class));
+    }
+
+    @Test
+    void attemptBid_buyNowPrice_success() {
+        when(auctionProgressItemRepo.findByItemItemId(itemId)).thenReturn(Optional.of(progressItem));
+        int bidPrice = 10000;
+
+        boolean result = auctionBidService.attemptBid(itemId, userId, nickname, bidPrice);
+
+        assertTrue(result);
+        verify(auctionInfoRepo).save(any(AuctionInfo.class));
+        verify(auctionProgressItemRepo).save(any(AuctionProgressItem.class));
+        verify(auctionCompleteItemRepo).save(any(AuctionCompleteItem.class));
+    }
+
+    @Test
+    void attemptBid_bidNotHigher_fail() {
+        setupAuctionBidTest(2L, 8000);
+        int bidPrice = 5000;
+
+        CommonException exception = assertThrows(CommonException.class, () -> auctionBidService.attemptBid(itemId, userId, nickname, bidPrice));
+        assertEquals(ErrorCode.BID_NOT_HIGHER, exception.getErrorCode());
+    }
+
+    @Test
+    void attemptBid_sameUser_fail() {
+        setupAuctionBidTest(1L, 8000);  // 동일 사용자
+        int bidPrice = 9000;
+
+        CommonException exception = assertThrows(CommonException.class, () -> auctionBidService.attemptBid(itemId, userId, nickname, bidPrice));
+        assertEquals(ErrorCode.BIDDER_IS_SAME, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
🐛 경매 기능에 관한 레포지스토리 오류 수정
---
1. 경매 완료 아이템 ID로 경매 진행 중 물품을 검색할 때 레포지스토리 내 JPQL 메서드명이 잘못된 부분을 수정하였습니다.
    findByItemId -> findByItemItemId

2. 물품의 현재 최고 입찰가격 조회 시 발생한 오류를 수정하였습니다.
JPA에서는 JPQL을 통해 DTO를 반환하는 데 한계가 있습니다. 따라서 @Query와 DTO 생성자를 사용하여 DTO를 바로 조회하도록 수정하였습니다.




🐛 입찰 기능에 관한 기능오류 수정
---
1. 입찰 진행 시 최고입찰자 ID를 함께 수정합니다.
2. 경매 완료 시 Item 테이블의 isAuctionComplete Clume값을 변경합니다.
3. 입찰 요청자ID가 핀매자ID와 같을 경우 예외 처리합니다.




🎨 시간에 따른 입찰 완료 기능의 함수명 변경
---
transferCompletedAuctions() -> finishAuctionsByTime()
 


 
---
- [x] #42