### PR TITLE
🐛입찰 요청 시 컨트롤러 측에서 발생하던 타입 오류 수정

### DIFF
--- a/src/main/java/com/kcs3/panda/domain/auction/controller/AuctionBidController.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/controller/AuctionBidController.java
@@ -56,6 +56,7 @@ public class AuctionBidController {
         } catch (CommonException e) {
             return ResponseDto.fail(e);
         } catch (Exception e) {
+            log.error("입찰 요청 컨트롤러 에러 - {}", e.getMessage());
             throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/kcs3/panda/domain/auction/dto/AuctionBidRequestDto.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/dto/AuctionBidRequestDto.java
@@ -1,7 +1,9 @@
 package com.kcs3.panda.domain.auction.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record AuctionBidRequestDto(Long itemId,
-                                   int bidPrice,
+                                   @JsonProperty("price") int bidPrice,
                                    Long userId,
                                    String nickname
 ) {

--- a/src/main/java/com/kcs3/panda/domain/auction/repository/ItemRepository.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/repository/ItemRepository.java
@@ -16,7 +16,8 @@ import java.util.List;
 
 @Repository
 public interface  ItemRepository extends JpaRepository<Item, Long> {
-        Long findSellerIdByItemId(Long itemId);
+        @Query("SELECT i.seller.userId FROM Item i WHERE i.itemId = :itemId")
+        Long findSellerIdByItemId(@Param("itemId") Long itemId);
 
 
 


### PR DESCRIPTION
🐛 컨트롤러 타입 오류 수정
---
입찰 요청 시 입찰 요청자가 물품의 판매자가 아닌지 확인하기 위해 물품의 판매자 아이디를 검색합니다. 이때, jpa 메소드만으로는 하나의 column값만을 검색하는 것이 불가능하기 때문에 추가적인 쿼리문을 필요로 하였습니다. 이에 따라, jpql 쿼리문을 추가로 작성하여 오류를 수정하였습니다.

또한 API 명세서에 작성된 규칙과 DTO의 변수명이 달라 발생한 오류에 관해서는 @JsonProperty를 통해 json 규칙의 변수명을 명시함으로써 해결하였습니다.

🎨 로그 메시지 추가
---
컨트롤러 측에서 일반적이지 않은 서버 오류가 발생하였을 때, 해당 오류에 관한 자세한 내용을 추가적으로 console에 출력하도록 합니다.

---
- [x] #55