### PR TITLE
🐛 입찰 요청에 관한 동시성 제어

### DIFF
--- a/src/main/java/com/kcs3/panda/domain/auction/entity/AuctionProgressItem.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/entity/AuctionProgressItem.java
@@ -37,8 +37,6 @@ public class AuctionProgressItem extends BaseEntity {
 
     @Column(nullable = false)
     private Integer startPrice;
-
-    @Column(nullable = true)
     private Integer buyNowPrice;
 
     @Column(nullable = false)
@@ -55,6 +53,10 @@ public class AuctionProgressItem extends BaseEntity {
 
     @Column(nullable = false)
     private Integer maxPrice;
+
+    @Version
+    private Integer version;
+
 
     public static class AuctionProgressItemBuilder {
         public AuctionProgressItemBuilder startPrice(int startPrice) {


### PR DESCRIPTION
🐛 입찰 요청 시 동시성 제어 추가 
---
낙관적 락을 사용하여 복수의 사용자가 동시에 경매 입찰에 참여할 경우 발생할 수 있는 동시성 문제 해결