### PR TITLE
🚑 입찰 참여 시 조건을 제대로 확인하지 못하는 문제 수정

### DIFF
--- a/src/main/java/com/kcs3/panda/domain/auction/repository/AuctionProgressItemRepository.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/repository/AuctionProgressItemRepository.java
@@ -22,7 +22,7 @@ public interface AuctionProgressItemRepository extends JpaRepository<AuctionProg
     @Query("SELECT new com.kcs3.panda.domain.auction.dto.AuctionBidHighestDto(" +
                 "api.auctionProgressItemId, user.userId, user.userNickname, api.maxPrice) " +
             "FROM AuctionProgressItem api " +
-            "JOIN api.user user " +
+            "LEFT JOIN api.user user " +
             "WHERE api.auctionProgressItemId = :auctionProgressItemId")
     Optional<AuctionBidHighestDto> findHighestBidByAuctionProgressItemId(@Param("auctionProgressItemId") Long auctionProgressItemId);
 


### PR DESCRIPTION
🚑 입찰 참여 시 조건 확인 로직 수정
---
조건을 제대로 확인하지 못하는 문제를 수정하였습니다. 최고 가격 정보에 관한  Dto를 조회할 때 user 정보에 관한 조인을 lefr 조인으로 변경하고, Dto의 내용이 존재하지 않을 경우 예외 처리 합니다.