### PR TITLE
🐛시간당 경매 완료 작업 중 트랜젝션 처리 문제 해결

### DIFF
--- a/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/service/AuctionBidServiceImpl.java
@@ -105,7 +105,6 @@ public class AuctionBidServiceImpl implements AuctionBidService {
     }//end updateAuctionProgressItemMaxBid()
 
     @Override
-    @Transactional
     @Scheduled(cron = "30 * * * * *")  // 매 시간 정각에 실행
     public void finishAuctionsByTime() {
         LocalDateTime now = LocalDateTime.now();
@@ -125,7 +124,8 @@ public class AuctionBidServiceImpl implements AuctionBidService {
 
     }//end transferCompletedAuctions()
 
-    private void transferItemToComplete(AuctionProgressItem item) {
+    @Transactional
+    protected void transferItemToComplete(AuctionProgressItem item) {
         try {
             boolean isComplete = checkBidCompletionStatus(item);
             AuctionCompleteItem completeItem = buildAuctionCompleteItem(item, isComplete);


### PR DESCRIPTION
🐛시간당 경매 완료 작업 중 트랜젝션 처리 문제 해결
---
스케줄링 작업에서 경매 완료 처리 대상 물품 리스트 내 하나의 실패로 인해 전체 경매 완료 작업이 실패하는 문제를 수정하였습니다.  개별 항목의 작업이 실패하여도 다른 항목들이 정상적으로 처리되도록 트랜잭션 처리 로직이 개선되었습니다.