### PR TITLE
🐛스케줄링 작업 중 물품 정보를 받아오지 못하는 문제 해결

### DIFF
--- a/src/main/java/com/kcs3/panda/domain/auction/repository/AuctionProgressItemRepository.java
+++ b/src/main/java/com/kcs3/panda/domain/auction/repository/AuctionProgressItemRepository.java
@@ -26,6 +26,7 @@ public interface AuctionProgressItemRepository extends JpaRepository<AuctionProg
             "WHERE api.auctionProgressItemId = :auctionProgressItemId")
     Optional<AuctionBidHighestDto> findHighestBidByAuctionProgressItemId(@Param("auctionProgressItemId") Long auctionProgressItemId);
 
+    @Query("SELECT api FROM AuctionProgressItem api JOIN FETCH api.item WHERE api.bidFinishTime < :now")
     Optional<List<AuctionProgressItem>> findAllByBidFinishTimeBefore(LocalDateTime now);
 }
 


### PR DESCRIPTION
🐛경매 진행중 테이블 정보를 바탕으로 경매 아이템 테이블 정보를 가져오지 못한 문제 해결
---
경매 진행 중 테이블이 경매 물품 테이블과 fetch Lasy로 연결되어있어 경매 물품 테이블의 정보를 제대로 가져오지 못하는 문제가 있었습니다. fetch 조인을 사용하여 해당 문제를 해결하였습니다.